### PR TITLE
Add persistHighlight() and locals.bit to radix sort

### DIFF
--- a/graphs.coffee
+++ b/graphs.coffee
@@ -72,6 +72,8 @@ quicksort(0, VA.length - 1)
   """
   radix: """
 sort = (begin, end, bit) ->
+  VA.persistHighlight([begin..end])
+  VA.locals.bit = bit
   i = begin
   j = end
   mask = 1 << bit


### PR DESCRIPTION
Use persistHighlight() to highlight the working set of each sort call.
Set VA.locals.bit to the current value of bit.
