### PR TITLE
Allow for values outside of the range of [1..length]

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
               The "Stop" button won't save the state of your code, but will save the state of the array.
             </li>
             <li>
-              The items are the integers [1..length].
+              The items are integers in the range of 0 to 2^10-1. There may be duplicates.
             </li>
           </ul>
           <br />


### PR DESCRIPTION
Populate the array of values with numbers from 0 to 2^30-1.
Maintain a separate array of "indices" whose sort order matches the sort
order of the values. This allows for a nice even triangle when sorted,
whereas using the values directly would provide an uneven slope.

Update all of the swap and insert functions to take advantage of
CoffeeScript's array destructuring syntax. This means no more tmp
variables.

Reimplement shuffle as a Fisher-Yates shuffle.
