### PR TITLE
Don't blow away animation state on highlighting

### DIFF
--- a/graphs.coffee
+++ b/graphs.coffee
@@ -279,12 +279,12 @@ class VisualArray
   highlight: (indices) =>
     if !$.isArray indices
       indices = [indices]
-    @animationQueue.push(type: "highlight", indices: indices)
+    @animationQueuePush(type: "highlight", indices: indices)
 
   persistHighlight: (indices) =>
     if !$.isArray indices
       indices = [indices]
-    @animationQueue.push(type: "persistHighlight", indices: indices)
+    @animationQueuePush(type: "persistHighlight", indices: indices)
   
   saveInitialState: =>
     @animationValues = @values.slice()


### PR DESCRIPTION
The calls to VA.highlight() and VA.persistHighlight() were pushing an
animation frame that omitted all of the normal animation state,
including locals. This caused, for example, radix sort with a
VA.locals.bit = bit line to keep losing it's display of "bit" as it
cycled downwards, and only restoring it once it performed another swap.

Fix this by replacing @animationQueue.push() with @animationQueuePush().
