### PR TITLE
Make insertion sort adaptive and stable

### DIFF
--- a/graphs.coffee
+++ b/graphs.coffee
@@ -26,10 +26,10 @@ for x in [0...VA.length - 1]
   """
   insert: """
 for x in [1...VA.length]
-  y = 0
-  while VA.gt(x, y)
-    y++
-    if y == x
+  y = x
+  while VA.gt(y - 1, x)
+    y--
+    if y == 0
       break
   VA.insert(x, y)
   """


### PR DESCRIPTION
The traditional insertion sort should scan for the insertion point
leftwards from the right end of the sorted range. This does not improve
the asymptotic performance, but it makes insertion sort both adaptive
and stable, which are two reasons that it's still an important O(n^2)
sort.
