### PR TITLE
Simplify insertion sort and add a version using swaps

### DIFF
--- a/graphs.coffee
+++ b/graphs.coffee
@@ -27,11 +27,16 @@ for x in [0...VA.length - 1]
   insert: """
 for x in [1...VA.length]
   y = x
-  while VA.gt(y - 1, x)
+  while y > 0 and VA.gt(y - 1, x)
     y--
-    if y == 0
-      break
   VA.insert(x, y)
+  """
+  insertswap: """
+for x in [1...VA.length]
+  y = x
+  while y > 0 and VA.gt(y - 1, y)
+    VA.swap(y - 1, y)
+    y--
   """
   quick: """
 slowsort = (left, right) ->

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
       <button class="js-show-sort" id="bubble">Bubble</button>
       <button class="js-show-sort" id="select">Selection</button>
       <button class="js-show-sort" id="insert">Insertion</button>
+      <button class="js-show-sort" id="insertswap">Insertion with swaps</button>
       <button class="js-show-sort" id="quick">Quick</button>
       <button class="js-show-sort" id="msbradix">MSB Radix</button>
       <button class="js-show-sort" id="lsbradix">LSB Radix</button>


### PR DESCRIPTION
- It's not necessary to use a break in the original insertion sort
  logic; an extra condition in the loop will do just fine.
- Insertion is an unavoidable O(n) cost in traditional
  insertion sort (unlike its usage in the other sorts, where the
  operations that correspond to what it's used for are O(1) if
  additional memory is used). The version using swaps better reflects
  its time complexity.
